### PR TITLE
Updates setup.py to fix the installation issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,6 @@ setup(name              = 'JiraRobot',
 							'jira >= 0.25'
 				],
       packages          = ['JiraRobot'],
-      data_files        = [('JiraRobotTests', ['Tests/acceptance/JiraRobotTest.txt', 'Tests/acceptance/FILE.txt', 'Docs/JiraRobot-KeywordDocumentation.html'])],
+      data_files        = [('JiraRobotTests', ['Tests/Acceptance/JiraRobotTest.txt', 'Tests/Acceptance/FILE.txt', 'Docs/JiraRobot-KeywordDocumentation.html'])],
       download_url      = 'https://github.com/NaviNet/JiraRobot/tarball/1.0',
       )


### PR DESCRIPTION
The path to file JiraRobotTest.txt and FILE.txt were wrong. The Acceptance folder name was mentioned incorrect, due to which while installation, the setup would break and report an error for the file not found referenced under wrong path.